### PR TITLE
Fix service definition to apply the timeout

### DIFF
--- a/DependencyInjection/AsyncCommandExtension.php
+++ b/DependencyInjection/AsyncCommandExtension.php
@@ -24,7 +24,8 @@ class AsyncCommandExtension extends Extension
 
             $id = sprintf('enqueue.async_command.%s.run_command_processor', $client['name']);
             $container->register($id, RunCommandProcessor::class)
-                ->addArgument('%kernel.project_dir%', $client['timeout'])
+                ->addArgument('%kernel.project_dir%')
+                ->addArgument($client['timeout'])
                 ->addTag('enqueue.processor', [
                     'client' => $client['name'],
                     'command' => $client['command_name'] ?? Commands::RUN_COMMAND,


### PR DESCRIPTION
`addArgument` add only one argument at a time to the construtor, right now the timeout configured by the user is never applied and it's always the default (60) value, this fixes it.